### PR TITLE
Fix Mailer instance

### DIFF
--- a/src/LaravelSesServiceProvider.php
+++ b/src/LaravelSesServiceProvider.php
@@ -71,8 +71,9 @@ class LaravelSesServiceProvider extends ServiceProvider
             // on the mailer. This allows us to resolve mailer classes via containers
             // for maximum testability on said classes instead of passing Closures.
             $mailer = new SesMailer(
+                'SesMailer',
                 $app['view'],
-                $app['swift.mailer'],
+                app('mailer')->getSwiftMailer(),
                 $app['events']
             );
 


### PR DESCRIPTION
In Laravel 7.x is "swift.mailer" not a container anymore.
See here: https://laravel.com/docs/7.x/upgrade#markdown-mail-template-updates

Therefore this change is required for it to be working correctly.