### PR TITLE
fix: remove exit codes from __construct

### DIFF
--- a/src/SnsSetup.php
+++ b/src/SnsSetup.php
@@ -10,7 +10,6 @@ use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Str;
-use Symfony\Component\Console\Command\Command as SymfonyCommand;
 
 class SnsSetup
 {
@@ -66,13 +65,9 @@ class SnsSetup
 
         if ($this->exceptionCount > 0) {
             $console->error('Some setup tasks failed! Please review them manually in AWS Console!');
-
-            return SymfonyCommand::FAILURE;
         }
 
         $console->info('ALL COMPLETED!');
-
-        return SymfonyCommand::SUCCESS;
     }
 
     /**


### PR DESCRIPTION
This PR fixes `SnsSetup` object to avoid this kind of exceptions 👇🏼 
```
[2022-05-27 05:46:14.189] [d-V5CD5PJ1H][stdout]  Object of class Juhasev\LaravelSes\SnsSetup could not be converted to int
```