### PR TITLE
feat: add ping threshold and restart threshold configurations

### DIFF
--- a/src/Config/laravelses.php
+++ b/src/Config/laravelses.php
@@ -49,8 +49,30 @@ return [
     /**
      * Smtp Ping Threshold.
      *
-     * By default, the threshold is set to 100 seconds.
+     * Sets the minimum number of seconds required between two messages, before the server is pinged.
+     * If the transport wants to send a message and the time since the last message exceeds the specified threshold,
+     * the transport will ping the server first (NOOP command) to check if the connection is still alive.
+     *
+     * Amazon SES SMTP server automatically closes connections after 10 seconds of inactivity.
+     *
+     * For this reason we set the ping threshold to 10 seconds.
      */
 
     'ping_threshold' => env('SES_PING_THRESHOLD', 10),
+
+    /**
+     * Smtp Restart Threshold.
+     *
+     * Sets the maximum number of messages to send before re-starting the transport.
+     *
+     * By default, the threshold is set to 100 (and no sleep at restart).
+     */
+    'restart_threshold' => [
+
+        // The maximum number of messages (0 to disable)
+        'threshold' => env('SES_RESTART_THRESHOLD', 100),
+
+        // The number of seconds to sleep between stopping and re-starting the transport
+        'sleep' => env('SES_RESTART_SLEEP', 0),
+    ],
 ];

--- a/src/Config/laravelses.php
+++ b/src/Config/laravelses.php
@@ -44,5 +44,13 @@ return [
         'EmailComplaint' => EmailComplaint::class,
         'EmailLink' => EmailLink::class,
         'EmailOpen' => EmailOpen::class
-    ]
+    ],
+
+    /**
+     * Smtp Ping Threshold.
+     *
+     * By default, the threshold is set to 100 seconds.
+     */
+
+    'ping_threshold' => env('SES_PING_THRESHOLD', 10),
 ];

--- a/src/LaravelSesServiceProvider.php
+++ b/src/LaravelSesServiceProvider.php
@@ -70,10 +70,23 @@ class LaravelSesServiceProvider extends ServiceProvider
 
             $symfonyMailer = app('mailer')->getSymfonyTransport();
 
+            $sesConfig = $app->make('config')->get('laravelses');
+
             try {
-                $symfonyMailer->setPingThreshold($app->make('config')->get('laravelses')['ping_threshold']);
+                $symfonyMailer->setPingThreshold(
+                    (int) Arr::get($sesConfig, 'ping_threshold', 10)
+                );
             } catch (Exception $e) {
-                logger("Unable to set ping threshold for Symfony Mailer. ".$e->getMessage());
+                logger("Unable to set ping threshold on Symfony Mailer. ".$e->getMessage());
+            }
+
+            try {
+                $symfonyMailer->setRestartThreshold(
+                    (int) Arr::get($sesConfig, 'restart_threshold.threshold', 100),
+                    (int) Arr::get($sesConfig, 'restart_threshold.sleep', 0)
+                );
+            } catch (Exception $e) {
+                logger("Unable to set restart threshold on Symfony Mailer. ".$e->getMessage());
             }
 
             // Once we have created the mailer instance, we will set a container instance


### PR DESCRIPTION
Related to https://trello.com/c/p2t4KpoG/3449-ses-timeout-waiting-data-from-the-client-add-proper-handling-for-all-error-codes-questmindshare

## Summary

This PR adds the ability to adjust the "ping threshold" and the "restart threshold" configuration on Symfony Smtp Transport to avoid `451 Timeout waiting for data from client` error. 
It also sets the ping threshold to 10 seconds to be in sync with Amazon SES SMTP server that automatically closes connections after 10 seconds of inactivity.