### PR TITLE
fix: link tracking

### DIFF
--- a/src/MailProcessor.php
+++ b/src/MailProcessor.php
@@ -115,7 +115,10 @@ class MailProcessor
 
         foreach ($anchors as $anchor) {
             $originalUrl = $anchor->getAttribute('href');
-            $anchor->setAttribute('href', $this->createAppLink($originalUrl));
+
+            if ($originalUrl !== null) {
+                $anchor->setAttribute('href', $this->createAppLink($originalUrl));
+            }
         }
 
         $this->setEmailBody($dom->innerHtml);

--- a/src/MailProcessor.php
+++ b/src/MailProcessor.php
@@ -116,7 +116,7 @@ class MailProcessor
         foreach ($anchors as $anchor) {
             $originalUrl = $anchor->getAttribute('href');
 
-            if ($originalUrl !== null) {
+            if ((string) $originalUrl !== '') {
                 $anchor->setAttribute('href', $this->createAppLink($originalUrl));
             }
         }

--- a/tests/Unit/MailProcessorTest.php
+++ b/tests/Unit/MailProcessorTest.php
@@ -84,4 +84,25 @@ class MailProcessorTest extends UnitTestCase
         $this->assertEquals('https://click.me', $emailLink['original_url']);
         $this->assertEquals(1, $emailLink['sent_email_id']);
     }
+
+    public function testLinksWithoutHrefAreSkipped()
+    {
+        // Body of text with one link without href in it
+        $body = "This is a test body of text, <a>Empty Link</a>";
+
+        $sentEmail = ModelResolver::get('SentEmail')::create([
+            'email' => 'lamela@yahoo.com',
+            'message_id' => 'somerandomid@swift.generated'
+        ]);
+
+        $mailProcessor = new MailProcessor($sentEmail, $body);
+
+        $parsedBody = $mailProcessor->linkTracking()->getEmailBody();
+
+        // Make sure body of email is now correct
+        $this->assertEquals(
+            'This is a test body of text, <a>Empty Link</a>',
+            $parsedBody
+        );
+    }
 }

--- a/tests/Unit/MailProcessorTest.php
+++ b/tests/Unit/MailProcessorTest.php
@@ -87,21 +87,32 @@ class MailProcessorTest extends UnitTestCase
 
     public function testLinksWithoutHrefAreSkipped()
     {
-        // Body of text with one link without href in it
-        $body = "This is a test body of text, <a>Empty Link</a>";
-
         $sentEmail = ModelResolver::get('SentEmail')::create([
             'email' => 'lamela@yahoo.com',
             'message_id' => 'somerandomid@swift.generated'
         ]);
 
+        // test without href...
+        $body = "This is a test body of text, <a>Empty Link</a>";
+
         $mailProcessor = new MailProcessor($sentEmail, $body);
 
         $parsedBody = $mailProcessor->linkTracking()->getEmailBody();
 
-        // Make sure body of email is now correct
         $this->assertEquals(
             'This is a test body of text, <a>Empty Link</a>',
+            $parsedBody
+        );
+
+        // test with an empty href...
+        $body = "This is a test body of text, <a href=\"\">Empty Link</a>";
+
+        $mailProcessor = new MailProcessor($sentEmail, $body);
+
+        $parsedBody = $mailProcessor->linkTracking()->getEmailBody();
+
+        $this->assertEquals(
+            'This is a test body of text, <a href="">Empty Link</a>',
             $parsedBody
         );
     }


### PR DESCRIPTION
This PR fixes an issue on `MailProcessor::linkTracking()` method and it resolves #17.

Now, It proper applies link tracking by skipping anchor tags without `href` attribute or with an empty one.