### PR TITLE
refactor: improve message headers generation

### DIFF
--- a/src/SesMailer.php
+++ b/src/SesMailer.php
@@ -39,15 +39,16 @@ class SesMailer extends Mailer implements SesMailerInterface
      * Creates database entry for the sent email
      *
      * @param Email $message
+     * @param string $messageId
      * @return SentEmailContract
      * @throws LaravelSesTooManyRecipientsException
      */
-    public function initMessage(Email $message): SentEmailContract
+    public function initMessage(Email $message, string $messageId): SentEmailContract
     {
         $this->checkNumberOfRecipients($message);
 
         return ModelResolver::get('SentEmail')::create([
-            'message_id' => $message->generateMessageId(),
+            'message_id' => $messageId,
             'email' => $message->getTo()[0]->getAddress(),
             'batch_id' => $this->getBatchId(),
             'sent_at' => Carbon::now(),
@@ -203,17 +204,18 @@ class SesMailer extends Mailer implements SesMailerInterface
      */
     protected function sendSymfonyMessage(Email $message): void
     {
-        $headers = $message->getHeaders();
+        /**
+         * Append unique Message-ID to the headers. Please note AWS SES will store reference
+         * to message ID internally while the outgoing email with get another Message-ID specific to
+         * AWS SES. However, delivery reporting return the original set Message-ID.
+         */
+        $headers = $message->getPreparedHeaders();
 
-        $sentEmail = $this->initMessage($message);
+        $sentEmail = $this->initMessage($message, $headers->get('Message-ID')->toString());
 
-        $this->appendToHeaders($sentEmail, $headers);
+        $message->setHeaders($this->appendToHeaders($headers));
 
-        $message->setHeaders($headers);
-
-        $newBody = $this->setupTracking((string) $message->getHtmlBody(), $sentEmail);
-
-        $message->html($newBody);
+        $message->html($this->setupTracking((string) $message->getHtmlBody(), $sentEmail));
 
         // Sending email first, in case sendEvent fails
         parent::sendSymfonyMessage($message);
@@ -221,15 +223,11 @@ class SesMailer extends Mailer implements SesMailerInterface
         $this->sendEvent($sentEmail);
     }
 
-    /**
-     * Append unique Message-ID to the headers. Please note AWS SES will store reference
-     * to message ID internally while the outgoing email with get another Message-ID specific to
-     * AWS SES. However, delivery reporting return the original set Message-ID.
-     */
-    protected function appendToHeaders(SentEmailContract $sentEmail, Headers &$headers): void
+    protected function appendToHeaders(Headers $headers): Headers
     {
-        $headers->addIdHeader('Message-ID', $sentEmail->message_id);
         $headers->addTextHeader('X-SES-CONFIGURATION-SET', $this->getConfigurationSetName());
+
+        return $headers;
     }
 
     /**

--- a/src/SesMailer.php
+++ b/src/SesMailer.php
@@ -211,7 +211,7 @@ class SesMailer extends Mailer implements SesMailerInterface
          */
         $headers = $message->getPreparedHeaders();
 
-        $sentEmail = $this->initMessage($message, $headers->get('Message-ID')->toString());
+        $sentEmail = $this->initMessage($message, $headers->get('Message-ID')?->toString());
 
         $message->setHeaders($this->appendToHeaders($headers));
 

--- a/src/SesMailerInterface.php
+++ b/src/SesMailerInterface.php
@@ -10,7 +10,7 @@ use Symfony\Component\Mime\Email;
 
 interface SesMailerInterface
 {
-    public function initMessage(Email $message): SentEmailContract;
+    public function initMessage(Email $message, string $messageId): SentEmailContract;
 
     public function setupTracking($setupTracking, SentEmailContract $sentEmail): string;
 


### PR DESCRIPTION
This PR will improve the `Message-ID` generation by preparing the headers before storing the message in the database.

Using [`getPreparedHeaders()` method from `Symfony\Message`](https://github.com/symfony/symfony/blob/6.2/src/Symfony/Component/Mime/Message.php#L75) doesn't only add more relevant headers but it also improves the deliverability of the message itself.