### PR TITLE
Fix serviceprovider missing methods & allow SesMail to fetch last created SesSentEmail contract

### DIFF
--- a/src/LaravelSesServiceProvider.php
+++ b/src/LaravelSesServiceProvider.php
@@ -74,18 +74,22 @@ class LaravelSesServiceProvider extends ServiceProvider
             $sesConfig = $app->make('config')->get('laravelses');
 
             try {
-                $symfonyMailer->setPingThreshold(
-                    (int) Arr::get($sesConfig, 'ping_threshold', 10)
-                );
+                if (method_exists($symfonyMailer, 'setPingThreshold')) {
+                    $symfonyMailer->setPingThreshold(
+                        (int)Arr::get($sesConfig, 'ping_threshold', 10)
+                    );
+                }
             } catch (Exception $e) {
                 logger("Unable to set ping threshold on Symfony Mailer. ".$e->getMessage());
             }
 
             try {
-                $symfonyMailer->setRestartThreshold(
-                    (int) Arr::get($sesConfig, 'restart_threshold.threshold', 100),
-                    (int) Arr::get($sesConfig, 'restart_threshold.sleep', 0)
-                );
+                if (method_exists($symfonyMailer, 'setRestartThreshold')) {
+                    $symfonyMailer->setRestartThreshold(
+                        (int)Arr::get($sesConfig, 'restart_threshold.threshold', 100),
+                        (int)Arr::get($sesConfig, 'restart_threshold.sleep', 0)
+                    );
+                }
             } catch (Exception $e) {
                 logger("Unable to set restart threshold on Symfony Mailer. ".$e->getMessage());
             }

--- a/src/SesMailer.php
+++ b/src/SesMailer.php
@@ -34,8 +34,6 @@ class SesMailer extends Mailer implements SesMailerInterface
 {
     use TrackingTrait;
 
-    private $sentEmailModel = null;
-
     /**
      * Init message (this is always called)
      * Creates database entry for the sent email
@@ -57,15 +55,6 @@ class SesMailer extends Mailer implements SesMailerInterface
             'complaint_tracking' => $this->complaintTracking,
             'bounce_tracking' => $this->bounceTracking
         ]);
-    }
-
-    /**
-     * Return the generated SES SentEmail model instance
-     * @return SentEmailContract
-     */
-    public function getSentEmailModel(): SentEmailContract
-    {
-        return $this->sentEmailModel;
     }
 
     /**
@@ -216,20 +205,20 @@ class SesMailer extends Mailer implements SesMailerInterface
     {
         $headers = $message->getHeaders();
 
-        $this->sentEmailModel = $this->initMessage($message);
+        $sentEmail = $this->initMessage($message);
 
-        $this->appendToHeaders($this->sentEmailModel, $headers);
+        $this->appendToHeaders($sentEmail, $headers);
 
         $message->setHeaders($headers);
 
-        $newBody = $this->setupTracking((string) $message->getHtmlBody(), $this->sentEmailModel);
+        $newBody = $this->setupTracking((string) $message->getHtmlBody(), $sentEmail);
 
         $message->html($newBody);
 
         // Sending email first, in case sendEvent fails
         parent::sendSymfonyMessage($message);
 
-        $this->sendEvent($this->sentEmailModel);
+        $this->sendEvent($sentEmail);
     }
 
     /**


### PR DESCRIPTION
@juhasev 
This pull request fixes https://github.com/juhasev/laravel-ses/issues/19 
Both of those methods are only applicable for the Smtp driver and don't exist for the LOG or SES drivers.
PR simply checks that these methods exist, and if so it will continue to use them

PR also adds in a `getSentEmailModel()` method to the SesMailer which will return the last created instance of SesSentEmail model/contract instance.
The issue with Laravel 9 is that it has removed the SwiftMailer which allowed us to fetch the `message-id` via a mailable.
Using this added method, we can return the entire last created instance and use it directly to add the message_id (or anything else from the SES model) to another spot within our app.

The SentEmail listener would not work in our case because the only piece of unique data available in the listener (message-id) can no longer be saved during email creation.

Example usage:

```
$communication = Models\Communication::find($anotherID); // another local model with additional details

$handler = SesMail::enableAllTracking()
   ->setBatch(...)
   ->send(new Mailable);

$messageId = $handler->getSentEmailModel();

// Saving this messageId to our local model gives us a direct link to the SesSentEmail database model via message_id at time of email creation
$communication->message_id = $messageId;
$communication->save();

```