### PR TITLE
Add option for callback after creating ses model

### DIFF
--- a/src/SesMailer.php
+++ b/src/SesMailer.php
@@ -46,7 +46,7 @@ class SesMailer extends Mailer implements SesMailerInterface
     {
         $this->checkNumberOfRecipients($message);
 
-        return ModelResolver::get('SentEmail')::create([
+        $model = ModelResolver::get('SentEmail')::create([
             'message_id' => $message->generateMessageId(),
             'email' => $message->getTo()[0]->getAddress(),
             'batch_id' => $this->getBatchId(),
@@ -55,6 +55,13 @@ class SesMailer extends Mailer implements SesMailerInterface
             'complaint_tracking' => $this->complaintTracking,
             'bounce_tracking' => $this->bounceTracking
         ]);
+
+        $callback = $this->getTrackingModelCallback();
+        if ($callback) {
+            $callback($model);
+        }
+
+        return $model;
     }
 
     /**

--- a/src/SesMailerInterface.php
+++ b/src/SesMailerInterface.php
@@ -20,6 +20,10 @@ interface SesMailerInterface
 
     public function getBatch(): ?BatchContract;
 
+    public function setTrackingModelCallback(callable $callback): SesMailerInterface;
+
+    public function getTrackingModelCallback(): ?callable;
+
     public function enableOpenTracking(): SesMailerInterface;
 
     public function enableLinkTracking(): SesMailerInterface;

--- a/src/TrackingTrait.php
+++ b/src/TrackingTrait.php
@@ -51,6 +51,11 @@ trait TrackingTrait
     private $batch;
 
     /**
+     * @var callable|null
+     */
+    private $trackingModelCallback = null;
+
+    /**
      * Set tracking
      *
      * @param string $setupTracking
@@ -116,14 +121,37 @@ trait TrackingTrait
 
     /**
      * Get batch ID
-     * 
+     *
      * @return int|null
      */
-    public function getBatchId(): ?int 
+    public function getBatchId(): ?int
     {
         return $this->batch?->getId();
     }
-    
+
+    /**
+     * Set tracking model callback
+     *
+     * @param callable $callback
+     * @return SesMailerInterface
+     */
+    public function setTrackingModelCallback(callable $callback): SesMailerInterface
+    {
+        $this->trackingModelCallback = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Get tracking model callback
+     *
+     * @return callable|null
+     */
+    public function getTrackingModelCallback(): ?callable
+    {
+        return $this->trackingModelCallback;
+    }
+
     /**
      * Enable open tracking
      *


### PR DESCRIPTION
Still going briefly off this issue:
https://github.com/juhasev/laravel-ses/issues/24
message_id generation is fixed however I am still struggling with fetching the correct model of the email which was just sent.

The comment https://github.com/juhasev/laravel-ses/issues/24#issuecomment-1645337422 saying to use ModelResolver is not a good solution in my use case because there is a good chance our users could be sending multiple emails asyncronously to the same email address (we use a queue with multiple email workers), leaving the chance of the SQL query incorrectly fetching the correct SentEmail model.

The only solution is to grab the message_id _at some point_ during the email send process.
As I've mentioned, SwiftMailer previously had this built in but it seems to have been removed with Laravel 9 when it moved to SymfonyMailer.

With this pull request, I've added a "callback" option which is initiated after the SentEmail model has been created. 
This change allows us to grab the message_id right after the model has been created, plus additionally add any custom logic directly to the model (such as extra column data etc).

Example usage:

```
$communication = Models\Communication::find($anotherID); // another local model with additional details

$handler = SesMail::enableAllTracking()
   ->setBatch(...)
   ->setTrackingModelCallback(function (SentEmailContract $model) use ($communication) {
        // custom logic such as
       $model->custom_column = 'XYZ';

       // or
      $communication->message_id = $model->message_id;
      $communication->save();
    })
   ->send(new Mailable);
```