### PR TITLE
Replace paquettg/php-html-parser with supported library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,10 @@
         "aws/aws-sdk-php": "^3.288.0",
         "ramsey/uuid": "^4.3",
         "guzzlehttp/guzzle": "^7.8.1",
-        "paquettg/php-html-parser": "^3.1",
         "aws/aws-php-sns-message-validator": "^1.7",
         "symfony/psr-http-message-bridge": "^7.0",
-        "nyholm/psr7": "^1.0"
+        "nyholm/psr7": "^1.0",
+        "voku/simple_html_dom": "^4.8"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/src/MailProcessor.php
+++ b/src/MailProcessor.php
@@ -7,13 +7,8 @@ namespace Juhasev\LaravelSes;
 use Exception;
 use Juhasev\LaravelSes\Contracts\BatchContract;
 use Juhasev\LaravelSes\Contracts\SentEmailContract;
-use PHPHtmlParser\Dom;
-use PHPHtmlParser\Exceptions\ChildNotFoundException;
-use PHPHtmlParser\Exceptions\CircularException;
-use PHPHtmlParser\Exceptions\CurlException;
-use PHPHtmlParser\Exceptions\NotLoadedException;
-use PHPHtmlParser\Exceptions\StrictException;
 use Ramsey\Uuid\Uuid;
+use voku\helper\HtmlDomParser;
 
 class MailProcessor
 {
@@ -65,20 +60,13 @@ class MailProcessor
     }
 
     /**
-     * @throws ChildNotFoundException
-     * @throws CircularException
-     * @throws CurlException
-     * @throws NotLoadedException
-     * @throws StrictException
      * @throws Exception
      */
     public function linkTracking(): self
     {
-        $dom = new Dom;
-        $dom->loadStr($this->getEmailBody());
-        $anchors = $dom->find('a');
+        $dom = HtmlDomParser::str_get_html($this->getEmailBody());
 
-        foreach ($anchors as $anchor) {
+        foreach ($dom->findMulti('a') as $anchor) {
             $originalUrl = $anchor->getAttribute('href');
 
             if ((string) $originalUrl !== '') {

--- a/src/SesMailer.php
+++ b/src/SesMailer.php
@@ -18,11 +18,6 @@ use Juhasev\LaravelSes\Exceptions\LaravelSesMaximumSendingRateExceeded;
 use Juhasev\LaravelSes\Exceptions\LaravelSesSendFailedException;
 use Juhasev\LaravelSes\Exceptions\LaravelSesTemporaryServiceFailureException;
 use Juhasev\LaravelSes\Exceptions\LaravelSesTooManyRecipientsException;
-use PHPHtmlParser\Exceptions\ChildNotFoundException;
-use PHPHtmlParser\Exceptions\CircularException;
-use PHPHtmlParser\Exceptions\CurlException;
-use PHPHtmlParser\Exceptions\NotLoadedException;
-use PHPHtmlParser\Exceptions\StrictException;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Header\Headers;
 use Throwable;
@@ -132,12 +127,7 @@ class SesMailer extends Mailer implements SesMailerInterface
     }
 
     /**
-     * @throws ChildNotFoundException
-     * @throws CircularException
-     * @throws CurlException
      * @throws LaravelSesTooManyRecipientsException
-     * @throws NotLoadedException
-     * @throws StrictException
      */
     protected function sendSymfonyMessage(Email $message): void
     {

--- a/src/TrackingTrait.php
+++ b/src/TrackingTrait.php
@@ -8,11 +8,6 @@ use Exception;
 use Juhasev\LaravelSes\Contracts\BatchContract;
 use Juhasev\LaravelSes\Contracts\SentEmailContract;
 use Juhasev\LaravelSes\Models\Batch;
-use PHPHtmlParser\Exceptions\ChildNotFoundException;
-use PHPHtmlParser\Exceptions\CircularException;
-use PHPHtmlParser\Exceptions\CurlException;
-use PHPHtmlParser\Exceptions\NotLoadedException;
-use PHPHtmlParser\Exceptions\StrictException;
 
 /**
  * @psalm-suppress UndefinedMethod
@@ -35,11 +30,6 @@ trait TrackingTrait
 
     /**
      * @param string $setupTracking
-     * @throws ChildNotFoundException
-     * @throws CircularException
-     * @throws CurlException
-     * @throws NotLoadedException
-     * @throws StrictException
      * @throws Exception
      */
     public function setupTracking($setupTracking, SentEmailContract $sentEmail): string
@@ -90,7 +80,7 @@ trait TrackingTrait
     {
         return $this->batch?->getId();
     }
-    
+
     public function enableOpenTracking(): SesMailerInterface
     {
         $this->openTracking = true;


### PR DESCRIPTION
Hey guys
We're upgrading our project to Laravel 11.
We use laravel-websockets but it isn't supported in L11 anymore, so we're migrating to Laravel Reverb.

Reverb requires `guzzlehttp/psr7^2.7`, however laravel-ses uses the now extremely outdated `paquettg/php-html-parser` which uses `guzzlehttp/psr7^1.6`

You can see an open ticket here: https://github.com/paquettg/php-html-parser/issues/294
One user recommended migrating to `voku/simple_html_dom`:  https://github.com/voku/simple_html_dom

This pull request replaces `paquettg/php-html-parser` with `voku/simple_html_dom`.
The behaviour of both packages is extremely similar.
The only instance used here is in MailProcessor for finding all `<a href="">` and creating an ses link tracker.

Unit tests all succeeded after replacing the package.
![image](https://github.com/user-attachments/assets/348b9371-385b-4250-a401-b384761cde97)

Feel free to make changes :)